### PR TITLE
add the ability to send any message

### DIFF
--- a/src/main/java/info/faljse/SDNotify/SDNotify.java
+++ b/src/main/java/info/faljse/SDNotify/SDNotify.java
@@ -141,6 +141,16 @@ public class SDNotify {
     }
 
     /**
+     * Sends a custom message to the service manager.
+     * Example: "EXTEND_TIMEOUT_USEC=3000000" to extend the startup timeout
+     *
+     * @param message The message to be sent through sd_notify
+     */
+    public static void sendRaw(String message) {
+        SDNotify.getInstance().sendString(message);
+    }
+
+    /**
      * Determines whether the watchdog is enabled.
      * <p>
      * Based on sd_watchdog_enabled(3), the watchdog should be enabled if


### PR DESCRIPTION
We need this to send timeout extension messages. I figure there must be other messages to be sent beside the few that are implemented and the one I have in mind, so I figured providing the ability to send any message would be preferable to adding just the timeout extension