### PR TITLE
slf4j-api dependency scope provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.26</version>
+            <scope>provided</scope>
         </dependency>
         <!-- Test dependencies -->
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->


### PR DESCRIPTION
This PR changes the slf4j-api dependency scope to provided to prevent dependency convergence problems.